### PR TITLE
404 por no incluir los sources de bootstrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
       
 
   </div>
-  
+  <!--No se habían incluido los sources de Bootstrap y retornaba un estado 404-->
  <script src="resources/js/jquery-2.2.4.js"></script>
  <script src="resources/js/bootstrap.min.js"></script>
  <!-- Bootstrap  CSS -->


### PR DESCRIPTION
La consola de chrome retornaba estado 404 debido a que intentaba cargar los recursos de bootstrap y estos no fueron incluidos en el html